### PR TITLE
Fixing the Overflow in the Main Menu

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,7 +9,7 @@
       :style="cssVars"
     >
       <Sidebar class="fixed left-0 w-8" />
-      <div class="min-h-screen pl-[4rem]">
+      <div class="h-screen overflow-y-auto pl-[4rem]">
         <slot />
       </div>
     </div>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2022-2023 trobonox <hello@trobo.tech>

SPDX-License-Identifier: Apache-2.0
-->

# Fixing the Overflow in the Main Menu

I replaced the min-h-screen with h-screen and overflow-y-auto so that the main menu doesnt have static overflow without actually overflowing in macos.

