### PR TITLE
feat: add custom color option for cards

### DIFF
--- a/components/kanban/Card.vue
+++ b/components/kanban/Card.vue
@@ -5,7 +5,8 @@
 <template>
   <div
     ref="cardRef"
-    :class="[cardTextClassZoom, cardBackgroundColor, cardTextColor]"
+    :class="[cardTextClassZoom, (cardBackgroundColor.startsWith('#') ? '' : cardBackgroundColor), cardTextColor]"
+    :style="[cardBackgroundColor.startsWith('#') ? {'background-color': cardBackgroundColor} : {}]"
     class="kanban-card border-elevation-3 flex cursor-pointer flex-col items-start gap-1 border"
     @click.self="$emit('openKanbanModal', index, card)"
   >

--- a/components/kanban/Card.vue
+++ b/components/kanban/Card.vue
@@ -180,6 +180,10 @@ const cardTextColor = computed(() => {
         }
     }
 
+    if (cardBackgroundColor.value.startsWith("#")) {
+        return getContrast(cardBackgroundColor.value);
+    }
+
     return "text-gray-50";
 });
 

--- a/components/modal/Kanban.vue
+++ b/components/modal/Kanban.vue
@@ -258,17 +258,17 @@
               />
             </button>
             <button
-              :class="`h-7 w-7 rounded-full border border-white py-1 pl-1.5 pr-1`"
+              :class="`h-7 w-7 rounded-full py-1 pl-1.5 pr-1`"
               :style="{'background-color': customColor}"
               @click="setCardColor(columnID, cardID, customColor)"
             >
               <CheckIcon
                 v-if="isCustomColor"
-                class="h-4 w-4"
+                :class="['h-4', 'w-4', getContrast(customColor)]"
               />
               <PencilIcon
                 v-else
-                class="h-4 w-4"
+                :class="['h-4', 'w-4', getContrast(customColor)]"
               />
             </button>
             <div

--- a/components/modal/Kanban.vue
+++ b/components/modal/Kanban.vue
@@ -258,8 +258,9 @@
               />
             </button>
             <button
-              :class="`h-7 w-7 rounded-full bg-[${customColor}] border border-white py-1 pl-1.5 pr-1`"
-              @click="setCardColor(columnID, cardID, `bg-[${customColor}]`)"
+              :class="`h-7 w-7 rounded-full border border-white py-1 pl-1.5 pr-1`"
+              :style="{'background-color': customColor}"
+              @click="setCardColor(columnID, cardID, customColor)"
             >
               <CheckIcon
                 v-if="isCustomColor"
@@ -270,18 +271,21 @@
                 class="h-4 w-4"
               />
             </button>
-            <div class="flex flex-col gap-2 bg-elevation-2 rounded-md p-2" v-if="isCustomColor">
-              <input
-                ref="colorInput"
-                v-model="customColor"
-                class="bg-elevation-2 w-20 rounded-md px-2"
-                type="color"
-              >
+            <div
+              v-if="isCustomColor"
+              class="bg-elevation-2 flex flex-col gap-2 rounded-md p-2"
+            >
               <input
                 v-model="customColor"
                 class="bg-elevation-1 w-20 rounded-md px-2"
                 readonly="true"
                 type="text"
+              >
+              <input
+                ref="colorInput"
+                v-model="customColor"
+                class="bg-elevation-2 w-20 rounded-md px-2"
+                type="color"
               >
             </div>
           </div>
@@ -296,7 +300,7 @@ import type { Ref } from "vue";
 
 import emitter from "@/utils/emitter"
 import { generateUniqueID } from "@/utils/idGenerator";
-import { CheckIcon, PlusIcon, XMarkIcon, PencilIcon } from "@heroicons/vue/24/solid";
+import { CheckIcon, PencilIcon, PlusIcon, XMarkIcon } from "@heroicons/vue/24/solid";
 import { PhCheck, PhPencilSimple } from "@phosphor-icons/vue";
 //@ts-ignore
 import { Container, Draggable } from 'vue3-smooth-dnd';
@@ -309,18 +313,6 @@ const emit = defineEmits<{
     (e: "setCardTitle", columnID: string, cardIndex: number, title: string): void,
 }>();
 
-const presetColors = [
-    "bg-pink-600",
-    "bg-red-600",
-    "bg-orange-600",
-    "bg-yellow-600",
-    "bg-green-600",
-    "bg-teal-600",
-    "bg-blue-600",
-    "bg-purple-600",
-    "bg-elevation-2",
-];
-
 const columnID = ref("");
 const cardID = ref(0);
 const title = ref("");
@@ -328,9 +320,7 @@ const description = ref("");
 const tasks: Ref<Array<{finished: boolean; id?: string, name: string }>> = ref([]);
 const selectedColor = ref("");
 
-const isCustomColor = computed(() => {
-    return !presetColors.includes(selectedColor.value);
-});
+const isCustomColor = computed(() => selectedColor.value.startsWith('#'));
 const customColor = ref("#ffffff");
 
 const titleEditing = ref(false);
@@ -381,12 +371,9 @@ const initModal = (
     tasks.value = savedTasks;
     updateCardTasks();
 
-    if (selectedColorParam && presetColors.includes(selectedColorParam)) {
-        selectedColor.value = selectedColorParam || "bg-elevation-2";
-    } else {
-        // get custom color in between [ ]
-        customColor.value = selectedColorParam?.substring(4, selectedColorParam.length - 1) || "#ffffff";
-        selectedColor.value = `bg-[${customColor.value}]`;
+    selectedColor.value = selectedColorParam || "bg-elevation-2";
+    if (selectedColorParam?.startsWith('#')) {
+        customColor.value = selectedColorParam;
     }
 }
 
@@ -460,7 +447,7 @@ const setCardColor = (columnID: string, cardID: number, color: string) => {
 
 watch(customColor, (newVal, oldVal) => {
     if (newVal !== oldVal) {
-        setCardColor(columnID.value, cardID.value, `bg-[${newVal}]`);
+        setCardColor(columnID.value, cardID.value, newVal);
     }
 });
 

--- a/components/modal/Kanban.vue
+++ b/components/modal/Kanban.vue
@@ -257,6 +257,33 @@
                 class="h-4 w-4"
               />
             </button>
+            <button
+              :class="`h-7 w-7 rounded-full bg-[${customColor}] border border-white py-1 pl-1.5 pr-1`"
+              @click="setCardColor(columnID, cardID, `bg-[${customColor}]`)"
+            >
+              <CheckIcon
+                v-if="isCustomColor"
+                class="h-4 w-4"
+              />
+              <PencilIcon
+                v-else
+                class="h-4 w-4"
+              />
+            </button>
+            <div class="flex flex-col gap-2 bg-elevation-2 rounded-md p-2" v-if="isCustomColor">
+              <input
+                ref="colorInput"
+                v-model="customColor"
+                class="bg-elevation-2 w-20 rounded-md px-2"
+                type="color"
+              >
+              <input
+                v-model="customColor"
+                class="bg-elevation-1 w-20 rounded-md px-2"
+                readonly="true"
+                type="text"
+              >
+            </div>
           </div>
         </div>
       </div>
@@ -269,7 +296,7 @@ import type { Ref } from "vue";
 
 import emitter from "@/utils/emitter"
 import { generateUniqueID } from "@/utils/idGenerator";
-import { CheckIcon, PlusIcon, XMarkIcon } from "@heroicons/vue/24/solid";
+import { CheckIcon, PlusIcon, XMarkIcon, PencilIcon } from "@heroicons/vue/24/solid";
 import { PhCheck, PhPencilSimple } from "@phosphor-icons/vue";
 //@ts-ignore
 import { Container, Draggable } from 'vue3-smooth-dnd';
@@ -282,12 +309,29 @@ const emit = defineEmits<{
     (e: "setCardTitle", columnID: string, cardIndex: number, title: string): void,
 }>();
 
+const presetColors = [
+    "bg-pink-600",
+    "bg-red-600",
+    "bg-orange-600",
+    "bg-yellow-600",
+    "bg-green-600",
+    "bg-teal-600",
+    "bg-blue-600",
+    "bg-purple-600",
+    "bg-elevation-2",
+];
+
 const columnID = ref("");
 const cardID = ref(0);
 const title = ref("");
 const description = ref("");
 const tasks: Ref<Array<{finished: boolean; id?: string, name: string }>> = ref([]);
 const selectedColor = ref("");
+
+const isCustomColor = computed(() => {
+    return !presetColors.includes(selectedColor.value);
+});
+const customColor = ref("#ffffff");
 
 const titleEditing = ref(false);
 const titleInput: Ref<HTMLInputElement | null> = ref(null);
@@ -337,7 +381,13 @@ const initModal = (
     tasks.value = savedTasks;
     updateCardTasks();
 
-    selectedColor.value = selectedColorParam || "bg-elevation-2";
+    if (selectedColorParam && presetColors.includes(selectedColorParam)) {
+        selectedColor.value = selectedColorParam || "bg-elevation-2";
+    } else {
+        // get custom color in between [ ]
+        customColor.value = selectedColorParam?.substring(4, selectedColorParam.length - 1) || "#ffffff";
+        selectedColor.value = `bg-[${customColor.value}]`;
+    }
 }
 
 const enableTaskAddMode = () => {
@@ -407,6 +457,12 @@ const setCardColor = (columnID: string, cardID: number, color: string) => {
     selectedColor.value = color;
     emit('setCardColor', columnID, cardID, color);
 }
+
+watch(customColor, (newVal, oldVal) => {
+    if (newVal !== oldVal) {
+        setCardColor(columnID.value, cardID.value, `bg-[${newVal}]`);
+    }
+});
 
 defineExpose({ initModal });
 </script>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2022-2023 trobonox <hello@trobo.tech>

SPDX-License-Identifier: Apache-2.0
-->

# Pull request

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:
1. [x] Did you lint your code locally before submission?
2. [x] Did you test your feature thoroughly to ensure there are no bugs?
3. [ ] Does your feature introduce breaking changes?

### Please describe your changes
* add feature card custom color selection
* add new color selection for custom color in the card edit modal
* in Card component, if the selected color starts with '#', use css style background-color and use getContrast for the text color

### Additional context
Resolves #308
