### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/plugins/importedDirectives.js
+++ b/plugins/importedDirectives.js
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 import FloatingVue from 'floating-vue'
 import 'floating-vue/dist/style.css'
 import VueDragscroll from "vue-dragscroll";


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2022-2023 trobonox <hello@trobo.tech>

SPDX-License-Identifier: Apache-2.0
-->

# Pull request

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Please describe your changes
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.

### Additional context
<!-- You can delete this if there is nothing you want to add -->
